### PR TITLE
analysis of phase 1 tracking under CMSSW_9_0_0_pre4

### DIFF
--- a/HIRun2015Ana/macros/RiceStyle.h
+++ b/HIRun2015Ana/macros/RiceStyle.h
@@ -34,7 +34,7 @@ cout << "Welcome to Rice Heavy Ion group!! " << endl;
 
 //make Canvas
 
-TCanvas* makeCanvas(const char* name, const char *title, bool doLogx == false, bool doLogy == true ){
+TCanvas* makeCanvas(const char* name, const char *title, bool doLogx = false, bool doLogy = true ){
 	
 	// Start with a canvas
 	TCanvas *canvas = new TCanvas(name,title, 1, 1 ,600 ,600 );
@@ -115,7 +115,7 @@ void initSubPad(TPad* pad, int i)
   //printf("Pad: %p, index: %d\n",pad,i);
 
   pad->cd(i);
-  TPad *tmpPad = pad->GetPad(i);
+  TPad *tmpPad = (TPad*)pad->GetPad(i);
   tmpPad->SetLeftMargin  (0.20);
   tmpPad->SetTopMargin   (0.06);
   tmpPad->SetRightMargin (0.08);
@@ -240,7 +240,7 @@ vector<TPad*> makeMultiPad(const int num){//we only have 4,6,8 options for now
 		pad[7]->SetBottomMargin(0.30);
 	}
 
-	for( i = 0; i < num; i++){
+	for( int i = 0; i < num; i++){
 
 		temp.push_back( pad[i] );
 	}
@@ -395,7 +395,7 @@ TLegend* makeLegend(){
 
 }
 
-TGraphAsymmErrors* makeEfficiency(TH1D* hist1, TH1D* hist2, const char*Draw == "cp", EColor color = kBlack  ){
+TGraphAsymmErrors* makeEfficiency(TH1D* hist1, TH1D* hist2, const char*Draw = "cp", EColor color = kBlack  ){
 
 	TGraphAsymmErrors* temp = new TGraphAsymmErrors();
 	temp->Divide( hist1, hist2, Draw );
@@ -415,4 +415,3 @@ TLatex* makeLatex(const char* txt,  double x, double y){
 	return r;
 
 }
-	

--- a/HIRun2015Ana/macros/plotHist2D.C
+++ b/HIRun2015Ana/macros/plotHist2D.C
@@ -239,9 +239,9 @@ void plotHist2D() {
 
   //TCanvas *c9 = new TCanvas("c9","Fake Fraction",900,500);
   TCanvas* c9 = makeMultiCanvas("c9", "Fake Fraction", 2,1);
-  hDumEtaFak=(TH1F*) hDumEta2->Clone("hDumEtaMul"); fixedFontHist1D(hDumEtaFak, 1.05,1.2); hDumEtaFak->GetYaxis()->SetRangeUser(0.,0.09);
+  TH1F* hDumEtaFak=(TH1F*) hDumEta2->Clone("hDumEtaMul"); fixedFontHist1D(hDumEtaFak, 1.05,1.2); hDumEtaFak->GetYaxis()->SetRangeUser(0.,0.09);
   hDumEtaFak->GetYaxis()->SetTitle("Fake Reconstruction Fraction");
-  hDumPtFak=(TH1F*) hDumPt2->Clone("hDumPtMul"); fixedFontHist1D(hDumPtFak, 1.05,1.2); hDumPtFak->GetYaxis()->SetRangeUser(0,1);
+  TH1F* hDumPtFak=(TH1F*) hDumPt2->Clone("hDumPtMul"); fixedFontHist1D(hDumPtFak, 1.05,1.2); hDumPtFak->GetYaxis()->SetRangeUser(0,1);
   hDumPtFak->GetYaxis()->SetTitle("Fake Reconstruction Fraction");
   c9->cd(1); hDumEtaFak->Draw(); gFakEta->Draw("pc"); gFakEta2->Draw("pc"); legEta2->Draw();
   gPad->SetTicks(); gPad->SetLeftMargin(0.12); gPad->SetBottomMargin(0.13);
@@ -278,9 +278,9 @@ void plotHist2D() {
   gSecPt2->SetMarkerColor(2);
 
   TCanvas* c10 = makeMultiCanvas("c10", "Secondary Fraction", 2, 1);
-  hDumEtaSec=(TH1F*) hDumEta2->Clone("hDumEtaMul"); fixedFontHist1D(hDumEtaSec, 1.05,1.3); hDumEtaSec->GetYaxis()->SetRangeUser(0.,0.012);
+  TH1F* hDumEtaSec=(TH1F*) hDumEta2->Clone("hDumEtaMul"); fixedFontHist1D(hDumEtaSec, 1.05,1.3); hDumEtaSec->GetYaxis()->SetRangeUser(0.,0.012);
   hDumEtaSec->GetYaxis()->SetTitle("Non-Primary Reconstruction Fraction");
-  hDumPtSec=(TH1F*) hDumPt2->Clone("hDumPtMul"); fixedFontHist1D(hDumPtSec, 1.05, 1.3);hDumPtSec->GetYaxis()->SetRangeUser(0.,0.1);
+  TH1F* hDumPtSec=(TH1F*) hDumPt2->Clone("hDumPtMul"); fixedFontHist1D(hDumPtSec, 1.05, 1.3);hDumPtSec->GetYaxis()->SetRangeUser(0.,0.1);
   hDumPtSec->GetYaxis()->SetTitle("Non-Primary Reconstruction Fraction");
   c10->cd(1); hDumEtaSec->Draw(); gSecEta->Draw("pc"); gSecEta2->Draw("pc"); legEta2->Draw();
   gPad->SetTicks(); gPad->SetLeftMargin(0.15); gPad->SetBottomMargin(0.13); 

--- a/HIRun2015Ana/test/run_PbPb_cfg.py
+++ b/HIRun2015Ana/test/run_PbPb_cfg.py
@@ -29,7 +29,7 @@ process.tpRecoAssocGeneralTracks.label_tr = cms.InputTag("hiGeneralTracks")
 process.load("SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi")
 process.quickTrackAssociatorByHits.SimToRecoDenominator = cms.string('reco')
 
-process.load("SimTracker.TrackerHitAssociation.clusterTpAssociationProducer_cfi")
+process.load("SimTracker.TrackerHitAssociation.tpClusterProducer_cfi")
 
 # Input source
 process.source = cms.Source("PoolSource",
@@ -50,15 +50,15 @@ process.centralityBin.nonDefaultGlauberModel = cms.string("HydjetDrum5")
 process.HITrackCorrections.centralitySrc = cms.InputTag("centralityBin","HFtowers")
 process.HITrackCorrections.trackSrc = cms.InputTag("hiGeneralTracks")
 process.HITrackCorrections.qualityString = cms.string("highPurity")
-process.HITrackCorrections.pfCandSrc = cms.untracked.InputTag("particleFlowTmp")
+process.HITrackCorrections.pfCandSrc = cms.InputTag("particleFlowTmp")
 process.HITrackCorrections.jetSrc = cms.InputTag("akPu4CaloJets")
 # options
 process.HITrackCorrections.useCentrality = False
-process.HITrackCorrections.applyTrackCuts = True
+process.HITrackCorrections.applyTrackCuts = False
 process.HITrackCorrections.fillNTuples = False
-process.HITrackCorrections.applyVertexZCut = True
+process.HITrackCorrections.applyVertexZCut = False
 process.HITrackCorrections.doVtxReweighting = False
-process.HITrackCorrections.doCaloMatched = True
+process.HITrackCorrections.doCaloMatched = False
 # cut values
 process.HITrackCorrections.dxyErrMax = 3.0
 process.HITrackCorrections.dzErrMax = 3.0
@@ -73,12 +73,11 @@ process.HITrackCorrections.algoParameters = cms.vint32(4,5,6,7)
 process.HITrackCorrections.vtxWeightParameters = cms.vdouble(0.0306789, 0.427748, 5.16555, 0.0228019, -0.02049, 7.01258 )
 ###
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '75X_mcRun2_HeavyIon_v11', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '90X_upgrade2017_realistic_v6', '')
 ###
 process.p = cms.Path(
                       process.tpClusterProducer *
                       process.quickTrackAssociatorByHits *
                       process.tpRecoAssocGeneralTracks *
-                      process.centralityBin *
                       process.HITrackCorrections
 )


### PR DESCRIPTION
enabling analysis of phase 1 tracking under CMSSW_9_0_0_pre4, at the same time, turn off track cuts, vertex z cuts, and calo matched.